### PR TITLE
Adds completions check

### DIFF
--- a/packages/ace-linters/package.json
+++ b/packages/ace-linters/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ace-linters",
   "author": "Azat Alimov <mkslanc@gmail.com>",
-  "version": "1.7.0",
+  "version": "1.8.3",
   "scripts": {
     "clean": "rimraf build",
     "postbuild": "node postbuild.js",

--- a/packages/ace-linters/src/language-provider.ts
+++ b/packages/ace-linters/src/language-provider.ts
@@ -510,7 +510,7 @@ export class LanguageProvider {
                             } else if (completion["docMarkdown"]) {
                                 item.docHTML = CommonConverter.cleanHtml(this.options.markdownConverter!.makeHtml(completion["docMarkdown"]));
                             }
-                            if (editor["completer"]) {
+                            if (editor["completer"] && editor["completer"].completions) {
                                 editor["completer"].updateDocTooltip();
                             }
 


### PR DESCRIPTION
When`updateDocTooltip` is called it expects completions to be non-null. If completions is null we don't need to update the tooltip, so adds a check that it exists