### PR TITLE
Fix crash tokenizing a destroyed session via signature help

### DIFF
--- a/packages/ace-linters/src/components/signature-tooltip.ts
+++ b/packages/ace-linters/src/components/signature-tooltip.ts
@@ -11,6 +11,9 @@ export class SignatureTooltip extends BaseTooltip {
         clearTimeout(this.$mouseMoveTimer);
         clearTimeout(this.$showTimer);
         if (this.isOpen) {
+            // always follow the editor that produced the event; the previously
+            // active editor may have been destroyed since the tooltip opened
+            this.$activateEditor(editor);
             this.provideSignatureHelp();
         } else {
             this.$mouseMoveTimer = setTimeout(() => {
@@ -25,8 +28,14 @@ export class SignatureTooltip extends BaseTooltip {
     provideSignatureHelp = () => {
         if (!this.provider.options.functionality!.signatureHelp)
             return;
-        let cursor = this.$activeEditor!.getCursorPosition();
-        let session = this.$activeEditor!.session;
+        if (!this.$activeEditor?.session || this.$activeEditor.session["destroyed"]) {
+            // the active editor was destroyed; requesting signature help would
+            // tokenize a session whose document is gone
+            this.$hide();
+            return;
+        }
+        let cursor = this.$activeEditor.getCursorPosition();
+        let session = this.$activeEditor.session;
         let docPos = session.screenToDocumentPosition(cursor.row, cursor.column);
 
         this.provider.provideSignatureHelp(session, docPos, (tooltip) => {

--- a/packages/ace-linters/src/language-provider.ts
+++ b/packages/ace-linters/src/language-provider.ts
@@ -712,6 +712,11 @@ class SessionLanguageProvider {
         }
 
         bgTokenizer.$tokenizeRow = (row: number) => {
+            if (!bgTokenizer.doc) {
+                // the session was destroyed (session.destroy() nulls the
+                // background tokenizer's doc); there is nothing to tokenize
+                return bgTokenizer.lines[row] = [];
+            }
             var line = bgTokenizer.doc.getLine(row);
             var state = bgTokenizer.states[row - 1];
             var data = bgTokenizer.tokenizer.getLineTokens(line, state, row);

--- a/packages/ace-linters/tests/unit/destroyed-session.tests.ts
+++ b/packages/ace-linters/tests/unit/destroyed-session.tests.ts
@@ -1,0 +1,131 @@
+import * as ace from "ace-code";
+import {Ace} from "ace-code";
+import "ace-code/src/test/mockdom";
+//@ts-ignore
+window["self"] = {};
+
+import {LanguageProvider} from "../../src/language-provider";
+import {SignatureTooltip} from "../../src/components/signature-tooltip";
+import {Mode as HtmlMode} from "ace-code/src/mode/html";
+import {expect} from "chai";
+import {MockWorker} from "../../src/misc/mock-worker";
+import {ServiceManager} from "../../src/services/service-manager";
+
+describe('Destroyed editor/session safety', () => {
+    let editor: Ace.Editor;
+    let languageProvider: LanguageProvider;
+    let client: MockWorker, ctx: MockWorker;
+
+    beforeEach((done) => {
+        client = new MockWorker();
+        ctx = new MockWorker();
+        client.setEmitter(ctx);
+        ctx.setEmitter(client);
+
+        let manager = new ServiceManager(ctx);
+        manager.registerService("html", {
+            features: {completion: true, completionResolve: true, diagnostics: true, format: true, hover: true},
+            module: () => import("../../src/services/html/html-service"),
+            className: "HtmlService",
+            modes: "html"
+        });
+
+        languageProvider = LanguageProvider.create(client, {
+            functionality: {
+                hover: true,
+                completion: {
+                    overwriteCompleters: true
+                },
+                completionResolve: true,
+                format: true,
+                documentHighlights: false,
+                signatureHelp: false
+            }
+        });
+
+        editor = ace.edit(document.createElement('div'), {
+            value: "<h1>Juhu Kinners</h1>",
+            mode: new HtmlMode()
+        });
+
+        // wait for the worker handshake before tests start destroying editors,
+        // so no late $connected callback fires into a torn-down test
+        let onAnnotation = () => {
+            editor.session.off("changeAnnotation", onAnnotation);
+            done();
+        };
+        editor.session.on("changeAnnotation", onAnnotation);
+
+        languageProvider.registerEditor(editor);
+    });
+
+    // NB: assertions in this suite compare scalars (messages, ids) rather than
+    // editor/session objects — chai's inspection of a full editor graph in a
+    // failure message exhausts the heap.
+    it('getTokenAt should not throw after the editor is destroyed', () => {
+        let session = editor.session;
+        // sanity check: tokenization works while the session is alive
+        let thrownBefore: unknown;
+        try {
+            session.getTokenAt(0, 1);
+        } catch (error) {
+            thrownBefore = error;
+        }
+        expect(String(thrownBefore ?? "")).to.equal("");
+
+        // react wrappers destroy the editor on unmount; this nulls bgTokenizer.doc
+        editor.destroy();
+
+        // async consumers (e.g. signature help callbacks) may still hold the session
+        let thrownAfter: unknown;
+        try {
+            session.getTokenAt(0, 1);
+        } catch (error) {
+            thrownAfter = error;
+        }
+        expect(String(thrownAfter ?? "")).to.equal("");
+    });
+
+    it('SignatureTooltip.update should switch the active editor while the tooltip is open', () => {
+        let tooltip = new SignatureTooltip(languageProvider);
+        let otherEditor = ace.edit(document.createElement('div'), {
+            value: "<p>other</p>",
+            mode: new HtmlMode()
+        });
+
+        tooltip.$activateEditor(editor);
+        tooltip.isOpen = true;
+
+        // selection changed in another editor (e.g. the old one was unmounted and replaced)
+        tooltip.update(otherEditor);
+
+        expect(tooltip.$activeEditor?.id).to.equal(otherEditor.id);
+
+        tooltip.isOpen = false;
+        otherEditor.destroy();
+    });
+
+    it('SignatureTooltip.provideSignatureHelp should not request help for a destroyed editor', () => {
+        let tooltip = new SignatureTooltip(languageProvider);
+        languageProvider.options.functionality!.signatureHelp = true;
+
+        let requested = false;
+        //@ts-ignore
+        languageProvider.provideSignatureHelp = () => {
+            requested = true;
+        };
+
+        tooltip.$activateEditor(editor);
+        editor.destroy();
+
+        expect(() => tooltip.provideSignatureHelp()).to.not.throw();
+        expect(requested).to.equal(false);
+    });
+
+    afterEach(() => {
+        if (!editor.session?.destroyed) {
+            editor.destroy();
+        }
+        editor.container.remove();
+    });
+});


### PR DESCRIPTION
## Summary

Fixes the top JS error in `/admin/workflows/?/edit/node/?`):

```
TypeError: Cannot read properties of null (reading 'getLine')
  at t.$tokenizeRow (@cortexapps/ace-linters/build/ace-linters.js)
  at e.getTokens / e.getTokenAt
  at SignatureTooltip provideSignatureHelp callback
```

### Root cause

- `addSemanticTokenSupport()` replaces `bgTokenizer.$tokenizeRow` with a version that dereferences `bgTokenizer.doc` unguarded. When an editor is destroyed (e.g. a React wrapper unmounting), `session.destroy()` calls `bgTokenizer.setDocument(null)`, so `doc` is null.
- `SignatureTooltip.update()` skips `$activateEditor(editor)` while the tooltip is open, so `$activeEditor` can stay pointed at a destroyed editor. Every subsequent selection change in a live editor then requests signature help against the dead session; the response callback calls `session.getTokenAt` → patched `$tokenizeRow` → `null.getLine`. Because the throw also prevents the tooltip from ever resetting, this repeats on **every cursor move** — matching the bursty hundreds-of-errors-per-session pattern in RUM.

Upstream `mkslanc/ace-linters` has since removed the `$tokenizeRow` monkey-patch entirely (semantic tokens are applied as markers), so this crash is specific to the fork.

### Changes

- Guard `$tokenizeRow` when `bgTokenizer.doc` is null (returns an empty token row).
- `SignatureTooltip.update()` re-activates the editor that produced the event even while the tooltip is open.
- `provideSignatureHelp()` bails (and hides the tooltip) when the active editor's session is gone or destroyed.
- New unit suite `tests/unit/destroyed-session.tests.ts` covering all three (each watched failing first; the first test reproduces the production TypeError verbatim).

### Testing

- `npm run test:unit`: 78 passing (75 baseline + 3 new).
- `npm run build` compiles clean.

### Publishing note

`main` already carries an unpublished `1.8.3` version bump; publishing after merge picks up this fix. brain-app will consume it via a version bump (a `pnpm patch` with the same guard is going up separately to stop the bleeding immediately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
